### PR TITLE
Refactor encode_utf8 function for improved  performance

### DIFF
--- a/Shoproot/includes/external/api_local/classes/reqser/ClassReqser.php
+++ b/Shoproot/includes/external/api_local/classes/reqser/ClassReqser.php
@@ -1222,6 +1222,7 @@ class ClassReqser extends api_local\ApiBase {
     if(strtolower($charset) == 'utf-8' || $force_utf8 === true) {
       $supported_charsets = explode(',', strtoupper(ENCODE_DEFINED_CHARSETS));  
       $cur_encoding = (!empty($encoding) && $encoding !== false) && in_array(strtoupper($encoding), $supported_charsets) ? strtoupper($encoding) : mb_detect_encoding($string, ENCODE_DEFINED_CHARSETS, true);
+      // PatrickK 07-2024 In Einzelfällen kann es vorkommen, dass die Funktion mb_detect_encoding() nicht das richtige Encoding erkennt und z.B. SJIS zurückgibt, obwohl es UTF-8 ist. In diesem Fall wird trotzdem geprüft, ob es UTF-8 ist und dann zurückgegeben.
       if(($cur_encoding == 'UTF-8' || $cur_encoding == 'SJIS') && mb_check_encoding($string, 'UTF-8')) {
         return $string;
       } elseif ($cur_encoding !== false) {

--- a/Shoproot/includes/external/api_local/classes/reqser/ClassReqser.php
+++ b/Shoproot/includes/external/api_local/classes/reqser/ClassReqser.php
@@ -1220,13 +1220,9 @@ class ClassReqser extends api_local\ApiBase {
    */
   protected function encode_utf8($charset, $string, $encoding = '', $force_utf8 = false) {
     if(strtolower($charset) == 'utf-8' || $force_utf8 === true) {
-      // PatrickK 07-2024, wir erwarten in der Regel UTF-8, daher erst prüfen ob es UTF-8 ist, wenn nicht dann konvertieren
-      if ($encoding === false && mb_check_encoding($string, 'UTF-8')) {
-        return $string;
-      }
       $supported_charsets = explode(',', strtoupper(ENCODE_DEFINED_CHARSETS));  
       $cur_encoding = (!empty($encoding) && $encoding !== false) && in_array(strtoupper($encoding), $supported_charsets) ? strtoupper($encoding) : mb_detect_encoding($string, ENCODE_DEFINED_CHARSETS, true);
-      if($cur_encoding == 'UTF-8' && mb_check_encoding($string, 'UTF-8')) {
+      if(($cur_encoding == 'UTF-8' || $cur_encoding == 'SJIS') && mb_check_encoding($string, 'UTF-8')) {
         return $string;
       } elseif ($cur_encoding !== false) {
         return mb_convert_encoding($string, 'UTF-8', $cur_encoding);

--- a/Shoproot/includes/external/api_local/classes/reqser/ClassReqser.php
+++ b/Shoproot/includes/external/api_local/classes/reqser/ClassReqser.php
@@ -1220,11 +1220,13 @@ class ClassReqser extends api_local\ApiBase {
    */
   protected function encode_utf8($charset, $string, $encoding = '', $force_utf8 = false) {
     if(strtolower($charset) == 'utf-8' || $force_utf8 === true) {
+      // PatrickK 07-2024, wir erwarten in der Regel UTF-8, daher erst prüfen ob es UTF-8 ist, wenn nicht dann konvertieren
+      if (mb_check_encoding($string, 'UTF-8')) {
+        return $string;
+      }
       $supported_charsets = explode(',', strtoupper(ENCODE_DEFINED_CHARSETS));  
       $cur_encoding = (!empty($encoding) && $encoding !== false) && in_array(strtoupper($encoding), $supported_charsets) ? strtoupper($encoding) : mb_detect_encoding($string, ENCODE_DEFINED_CHARSETS, true);
-      if($cur_encoding == 'UTF-8' && mb_check_encoding($string, 'UTF-8')) {
-        return $string;
-      } elseif ($cur_encoding !== false) {
+      if ($cur_encoding !== false) {
         return mb_convert_encoding($string, 'UTF-8', $cur_encoding);
       } else {
         return mb_convert_encoding($string, 'UTF-8', strtoupper($charset));

--- a/Shoproot/includes/external/api_local/classes/reqser/ClassReqser.php
+++ b/Shoproot/includes/external/api_local/classes/reqser/ClassReqser.php
@@ -1221,12 +1221,14 @@ class ClassReqser extends api_local\ApiBase {
   protected function encode_utf8($charset, $string, $encoding = '', $force_utf8 = false) {
     if(strtolower($charset) == 'utf-8' || $force_utf8 === true) {
       // PatrickK 07-2024, wir erwarten in der Regel UTF-8, daher erst prüfen ob es UTF-8 ist, wenn nicht dann konvertieren
-      if (mb_check_encoding($string, 'UTF-8')) {
+      if ($encoding === false && mb_check_encoding($string, 'UTF-8')) {
         return $string;
       }
       $supported_charsets = explode(',', strtoupper(ENCODE_DEFINED_CHARSETS));  
       $cur_encoding = (!empty($encoding) && $encoding !== false) && in_array(strtoupper($encoding), $supported_charsets) ? strtoupper($encoding) : mb_detect_encoding($string, ENCODE_DEFINED_CHARSETS, true);
-      if ($cur_encoding !== false) {
+      if($cur_encoding == 'UTF-8' && mb_check_encoding($string, 'UTF-8')) {
+        return $string;
+      } elseif ($cur_encoding !== false) {
         return mb_convert_encoding($string, 'UTF-8', $cur_encoding);
       } else {
         return mb_convert_encoding($string, 'UTF-8', strtoupper($charset));


### PR DESCRIPTION
Updated handling of utf-8 encoding as for example™ was interpreted as SJIS instead of UTF-8: mb_detect_encoding() might detect SJIS because the byte sequence for the trademark symbol (™) matches the expected byte sequence in SJIS. A possible solution would be to place UTF-8 first. With that, we could increase the likelihood that mb_detect_encoding will detect UTF-8 if the string is valid in that encoding. As this didn't work out, i came up with this approach.
This new approach ensures that if the string is already valid UTF-8, it is returned immediately without further processing. If it is not valid UTF-8, the code proceeds to detect the encoding and convert the string to UTF-8 as needed.